### PR TITLE
Add Avocode to Graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@
 - [Acorn](https://secure.flyingmeat.com/acorn/) - A very Mac-like image editor with a comprehensive feature set.
 - [Affinity Designer](https://affinity.serif.com/en-us/designer/) - Vector image design tool, possible Adobe Illustrator alternative.
 - [Affinity Photo](https://affinity.serif.com/en-us/photo/) - Raster image design tool, possible Adobe Photoshop alternative.
+- [Avocode](http://avocode.com) - The bridge between designers and developers. A way to share designs, export assets and collaborate with your team.
 - [Blender](https://www.blender.org/) - Fully-featured extensible cross-platform 3D content suite. [![Open-Source Software][OSS Icon]](https://developer.blender.org/)
 - [Image2icon](http://www.img2icnsapp.com) - Create and personalize icons from your pictures.
 - [OmniGraffle](https://www.omnigroup.com/omnigraffle) - An app for creating precise, beautiful graphics.


### PR DESCRIPTION
Avocode - The bridge between designers and developers. A way to share designs, export assets and collaborate with your team.