### PR TITLE
Add Jump Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@
 - [Helium](http://heliumfloats.com/) - A floating browser window that allows you to watch media while you work. [![Open-Source Software][OSS Icon]](https://github.com/JadenGeller/Helium)
 - [InsomniaX](http://semaja2.net/projects/insomniaxinfo/) - Prevents OS X from automatically going to sleep (on lid closing or idle timeout).
 - [iStat Menus](https://bjango.com/mac/istatmenus/) - An advanced system monitor for your menubar.
+- [Jump Desktop](https://jumpdesktop.com) - A powerful RDP and VNC client with built-in support for SSH tunnelling and zero config setup.
 - [Kawa](https://github.com/noraesae/kawa) - A better input source switcher with shortcuts. [![Open-Source Software][OSS Icon]](https://github.com/noraesae/kawa)
 - [KeePassX](https://www.keepassx.org) - A free, open source, and light-weight password manager. [![Open-Source Software][OSS Icon]](https://github.com/keepassx/keepassx)
 - [KeepingYouAwake](https://github.com/newmarcel/KeepingYouAwake) - Menu bar utility that prevents Mac from going to sleep. [![Open-Source Software][OSS Icon]](https://github.com/newmarcel/KeepingYouAwake)


### PR DESCRIPTION
Jump Desktop is a remote desktop (RDP and VNC client). It's available on the Mac App Store: http://itunes.apple.com/us/app/jump-desktop-remote-desktop/id524141863?ls=1&mt=12