### PR TITLE
Added Dropzone to the productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@
 - [BetterTouchTool](https://www.boastr.net/) - Configure gestures for mouse and actions for keyboard shortcuts.
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. ![Freeware][Freeware Icon]
 - [CloudClip](http://www.thinkbitz.com/cloudclip/) - Sync your clipboard between your Mac and your iOS devices. ![Freeware][Freeware Icon]
+- [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.
 - [f.lux](https://justgetflux.com/) - Automatically adjust your computer screen to match lighting. ![Freeware][Freeware Icon]
 - [Fantastical 2](https://flexibits.com/fantastical) - Complete Calendar app replacement which uses natural language for creating events.
 - [Hazel](https://www.noodlesoft.com/hazel.php) - Create rules to automatically keep your files organized.


### PR DESCRIPTION
Just found this repository and think it's really neat. Have added a paid productivity app that I'm the developer of. It's available both in and out of the Mac store and also has a 15 day trial.

Project URL: https://aptonic.com/

Why should this project be added: It's a fairly popular Mac App - see here: https://www.macupdate.com/app/mac/31794/dropzone