### PR TITLE
Remove freeware icon from Deliveries

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@
 - [CommandQ](https://clickontyler.com/commandq/) - Never accidentally quit an app again.
 - [ControlPlane](http://www.controlplaneapp.com/) - Automate running tasks based on where you are or what you do. [![Open-Source Software][OSS Icon]](https://github.com/dustinrue/ControlPlane) ![Freeware][Freeware Icon]
 - [DaisyDisk](https://daisydiskapp.com/) - Analyze disk usage and free up disk space.
-- [Deliveries](http://junecloud.com/software/mac/deliveries.html) - Beautiful and simple package tracking. ![Freeware][Freeware Icon]
+- [Deliveries](http://junecloud.com/software/mac/deliveries.html) - Beautiful and simple package tracking.
 - [DisableMonitor](https://github.com/Eun/DisableMonitor) - Easily disable or enable a monitor on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Eun/DisableMonitor) ![Freeware][Freeware Icon]
 - [EtreCheck](http://etrecheck.com) - Output system information and configuration to get more informed help from Apple support professionals. [![Open-Source Software][OSS Icon]](https://github.com/etresoft/EtreCheck) ![Freeware][Freeware Icon]
 - [Finicky](https://johnste.github.io/finicky/) - App that allows you to set rules that decide which browser is opened for every link. [![Open-Source Software][OSS Icon]](https://github.com/johnste/finicky) ![Freeware][Freeware Icon]


### PR DESCRIPTION
[Not free](https://itunes.apple.com/pt/app/deliveries-a-package-tracker/id924726344).
![image](https://cloud.githubusercontent.com/assets/1699443/18394927/2bff8faa-76b4-11e6-8950-ddc65fd606bf.png)

Did not fill the template since it does not apply here (edit, not an addition).