### PR TITLE
Remove Zooom/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,6 @@
 - [Phoenix](https://github.com/kasper/phoenix) - A lightweight window and app manager scriptable with JavaScript. [![Open-Source Software][OSS Icon]](https://github.com/Hammerspoon/hammerspoon) ![Freeware][Freeware Icon]
 - [Spectacle](https://www.spectacleapp.com/) - Easily organize windows without using a mouse. [![Open-Source Software][OSS Icon]](https://github.com/eczarny/spectacle) ![Freeware][Freeware Icon]
 - [Stay](https://cordlessdog.com/stay/) - Resize/position windows when displays change.
-- [Zooom/2](http://coderage-software.com/zooom/index_green/index.html) - Mac window management.
-
 
 ### Others
 


### PR DESCRIPTION
Looks like the product is discontinued, originally added in #222

http://coderage-software.com/index.html

![screen shot 2017-01-18 at 7 49 43 am](https://cloud.githubusercontent.com/assets/4723115/22071032/c213991e-dd52-11e6-88de-cb5a54745021.png)
