### PR TITLE
Add Touch Bar Simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 - [Sip](http://theolabrothers.com/) - A simple color picker for developers.
 - [SnippetsLab](https://www.renfei.org/snippets-lab/) - Manage and organise snippets of code.
 - [SourceTree](https://www.sourcetreeapp.com/) - A free Git & Mercurial client. ![Freeware][Freeware Icon]
+- [Touch Bar Simulator](https://github.com/sindresorhus/touch-bar-simulator) - The macOS Touch Bar Simulator as a standalone app. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/touch-bar-simulator) ![Freeware][Freeware Icon]
 - [Tower](https://www.git-tower.com/) - The most powerful Git client.
 - [Unused](https://jeffhodnett.github.io/Unused/) - An app for checking Xcode projects for unused resources. [![Open-Source Software][OSS Icon]](https://github.com/jeffhodnett/Unused) ![Freeware][Freeware Icon]
 - [Vagrant Manager](http://vagrantmanager.com) - Manage your vagrant machines in one place with Vagrant Manager for macOS. [![Open-Source Software][OSS Icon]](https://github.com/lanayotech/vagrant-manager/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] Project URL: https://github.com/sindresorhus/touch-bar-simulator
1. [x] Why should this project be added: it makes easier to code and design for the Touch Bar (if person doesn't want or can't launch the simulator from inside Xcode)
2. [x] End all descriptions with a full stop/period
3. [x] Entry is ordered alphabetically
4. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

For more information, read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md

-->
