### PR TITLE
Add SpaceLauncher

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@
 - [Quicksilver](https://qsapp.com/) - Control your Mac quickly and elegantly. [![Open-Source Software][OSS Icon]](https://github.com/quicksilver/Quicksilver) ![Freeware][Freeware Icon]
 - [SelfControl](https://selfcontrolapp.com/) - Block access to distracting websites. [![Open-Source Software][OSS Icon]](https://github.com/SelfControlApp/selfcontrol/) ![Freeware][Freeware Icon]
 - [Simplenote](https://simplenote.com/) - Simple cross-platform note taking app with cloud-based syncing. ![Freeware][Freeware Icon]
+- [SpaceLauncher](https://spacelauncherapp.com/) - Hold down spacebar while pressing a key to launch or switch to an app.
 - [TaskPaper](https://www.taskpaper.com/) - Plain text to-do lists.
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] Project URL: https://spacelauncherapp.com/
1. [x] Why should this project be added:

Before macOS Sierra, I used to launch or switch to an app with [Brett](http://brettterpstra.com/contact/)'s ["hyper key" configurations](http://brettterpstra.com/2012/12/08/a-useful-caps-lock-key/). It remaps Caps Lock key (called "hyper key") to Command+Shift+Option+Control via [Karabiner](https://pqrs.org/osx/karabiner/), and use "hyper key" + another key to launch or switch to an app. It saved me a lot of time.

However, Karabiner is not compatible with macOS Sierra. After the upgrade, I really missed the configuration. Without "hyper key", I had to use Dock, Command+Tab, Launchpad or Mission Control to switch apps. I started to notice I was distracted with locating the target app I want to switch to.

SpaceLauncher lets users launch or switch to an app by holding down the spacebar while pressing a key. Spacebar is so easy to be pressed and combined with another key to switch apps. This makes my workflow much smooth and less distraction. I hope others can also benefit from SpaceLauncher.

2. [x] End all descriptions with a full stop/period
3. [x] Entry is ordered alphabetically
4. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

For more information, read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md

-->