### PR TITLE
Add Timing for Mac (automatic time tracker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@
 - [TaskPaper](https://www.taskpaper.com/) - Plain text to-do lists.
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
+- [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
 
 
 ### Sharing Files


### PR DESCRIPTION
Project page: https://timingapp.com

This commit adds another time tracking app to the list. For testimonials of its awesomeness, see [our Product Hunt page](https://www.producthunt.com/posts/timing-2-3) and [the old version's Mac App Store page](https://itunes.apple.com/us/app/id431511738?mt=12&ign-mpt=uo%3D4). Also happy to send you a free copy so you can see for yourself :-)

Was also suggested in #431 already.