### PR TITLE
Add Vanilla

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@
 - [Ukelele](http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=ukelele) - Unicode Keyboard Layout Editor. ![Freeware][Freeware Icon]
 - [Übersicht](http://tracesof.net/uebersicht/) - Run system commands and display their output on your desktop as widgets. [![Open-Source Software][OSS Icon]](https://github.com/felixhageloh/uebersicht) ![Freeware][Freeware Icon]
 - [The Unarchiver](http://unarchiver.c3.cx/unarchiver) - Unarchive many different kinds of archive files. [![Open-Source Software][OSS Icon]](https://bitbucket.org/WAHa_06x36/theunarchiver) ![Freeware][Freeware Icon]
+- [Vanilla](http://matthewpalmer.net/vanilla/) - Hide menu bar icons on your Mac.
 - [Wineskin](http://wineskin.urgesoftware.com/tiki-index.php) - Run Windows applications and games on your Mac. [![Open-Source Software][OSS Icon]](https://sourceforge.net/p/wineskin/code/ci/master/tree/) ![Freeware][Freeware Icon]
 
 ### Video


### PR DESCRIPTION
http://matthewpalmer.net/vanilla/

Vanilla is a small (and free!) utility to hide individual icons on your Mac. No freeware icon because Vanilla Premium is offered.

Thanks!

<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [X] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [X] Project URL: http://matthewpalmer.net/vanilla/
2. [X] Why should this project be added:
3. [X] End all descriptions with a full stop/period
4. [X] Entry is ordered alphabetically
5. [X] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->