### PR TITLE
Add TablePlus

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@
 - [SnippetsLab](https://www.renfei.org/snippets-lab/) - Manage and organise snippets of code.
 - [SourceTree](https://www.sourcetreeapp.com/) - A free Git & Mercurial client. ![Freeware][Freeware Icon]
 - [Swiftify](https://objectivec2swift.com/#/xcode-extension/) - Objective-C to Swift code converter and Xcode & Finder extensions.
+- [TablePlus](https://tableplus.io) - A relational database client supporting PostgreSQL, MySQL, MariaDB, MS SQL, Amazon Redshift and SQLite. ![Freeware][Freeware Icon]
 - [Touch Bar Simulator](https://github.com/sindresorhus/touch-bar-simulator) - The macOS Touch Bar Simulator as a standalone app. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/touch-bar-simulator) ![Freeware][Freeware Icon]
 - [Tower](https://www.git-tower.com/) - The most powerful Git client.
 - [Unused](https://jeffhodnett.github.io/Unused/) - An app for checking Xcode projects for unused resources. [![Open-Source Software][OSS Icon]](https://github.com/jeffhodnett/Unused) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: https://tableplus.io
2. [x] Why should this project be added: This is a native application supporting many databases. It has a very good and lightweight UI, syntax highlighting, autosuggestion (SQL syntax, tables, columns), he history and partial code execution (what you've selected). 
3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)

However, I'm not quite sure about "Free" icon. There is paid plan but it's totally ok to use a free option for personal purposes. Paid plan suggests themes, more than 4 connection, etc.