### PR TITLE
Add link to fman (dual-pane file manager)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
 
 ### Finder
 
+- [fman](https://fman.io) - Modern dual-pane file manager integrating features from Sublime Text.
 - [ForkLift](https://itunes.apple.com/us/app/forklift-file-manager-ftp/id412448059) - File Manager and FTP/SFTP/WebDAV/Amazon S3 client.
 - [Path Finder](http://www.cocoatech.com/pathfinder/) - A powerful dual-pane browser alternative to Finder.
 - [Quicklook-Plugins](https://github.com/sindresorhus/quick-look-plugins) - List of extra quicklook plugins to enable previewing more filetypes in the Finder.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: https://fman.io
2. [x] Why should this project be added:
fman is the most modern dual-pane file manager and the first to integrate innovative features from Sublime Text. When it launched in March 2017, fman made the top 10 on Product Hunt and stayed on the front page of Hacker News for more than 13 hours.
3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)

The default spelling for fman is with a lower-case 'f'. I left it like that for that reason even though `contributing.md` says to capitalize titles. However, I would also be happy to capitalize it if you like. Just let me know please and I'll update this PR.

fman is [not based on Electron for performance reasons](https://fman.io/blog/picking-technologies-for-a-desktop-app-in-2016/).
  