### PR TITLE
Audio Profile Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 ### Audio
 
 - [Audio Hijack](http://www.rogueamoeba.com/audiohijack/) - Record audio from any application like iTunes, Skype or Safari, or from hardware devices like microphones and mixers.
+- [Audio Profile Manager](https://apps.apple.com/us/app/audio-profile-manager/id1484150558?ls=1&mt=12) - Allows you to pin input/output devices for each particular combination of connected devices. May suppress HDMI displays from being choosen.
 - [BackgroundMusic](https://github.com/kyleneideck/BackgroundMusic) - Record system audio, control audio levels for individual apps, and automatically pauses your music player when other audio starts playing and unpauses it afterwards. [![Open-Source Software][OSS Icon]](https://github.com/kyleneideck/BackgroundMusic) ![Freeware][Freeware Icon]
 - [VOX Player](https://coppertino.com/vox/mac) - Play numerous lossy and lossless audio formats.
 - [XLD](http://tmkk.undo.jp/xld/index_e.html) - Rip/Decode/convert/play various "lossless" audio files. [![Open-Source Software][OSS Icon]](https://code.google.com/archive/p/xld/source) ![Freeware][Freeware Icon]


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [X] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [X] Project URL:https://apps.apple.com/us/app/audio-profile-manager/id1484150558?ls=1&mt=12
2. [X] Why should this project be added: it's very annoying to always choose input/output devices manually each time your hardware configuration changes. It's especially annoying when you have HDMI devices as per MacOS prefers to choose them. Surprisingly there are no apps which can do the same (or I'm totally unaware)
3. [X] End all descriptions with a full stop/period
4. [X] Entry is ordered alphabetically
5. [X] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->
