### PR TITLE
Add "1440 Minutes Left Today"

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@
 
 ### Productivity
 
+- [1440 Minutes Left Today](https://1440app.com/) - Keep a track of how many minutes you have left until the day is over, right in your menu bar. ![Freeware][Freeware Icon]
 - [Alfred](https://www.alfredapp.com/) - Boosts your efficiency and productivity.
 - [BetterTouchTool](https://www.boastr.net/) - Configure gestures for mouse and actions for keyboard shortcuts.
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: http://1440app.com
2. [x] Why should this project be added:

1440 Minutes Left Today is a small and very simple menu bar app. It shows you how many minutes you have left until the day is over. There are plenty of groups which can benefit from it:

- Procrastinators can use it as a little motivator to use their time wisely.
- Night owls can use it as a reminder to go to bed at a reasonable hour.
- Photographers and other creatives doing 365/30/... days projects can use it to produce something every day before midnight.

3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->
