### PR TITLE
Storyboard -> SwiftUI Converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@
 - [Sequel Pro](http://www.sequelpro.com/) - A MySQL database manager. [![Open-Source Software][OSS Icon]](https://github.com/sequelpro/sequelpro) ![Freeware][Freeware Icon]
 - [SnippetsLab](https://www.renfei.org/snippets-lab/) - Manage and organise snippets of code.
 - [SourceTree](https://www.sourcetreeapp.com/) - A free Git & Mercurial client. ![Freeware][Freeware Icon]
+- [Storyboard -> SwiftUI Converter](https://swiftify.com/#/converter/storyboard2swiftui/) - Convert Storyboard and Xib to SwiftUI.
 - [Swiftify](https://objectivec2swift.com/#/xcode-extension/) - Objective-C to Swift code converter and Xcode & Finder extensions.
 - [TablePlus](https://tableplus.com/) - A modern, native GUI for multiple databases.
 - [Touch Bar Simulator](https://github.com/sindresorhus/touch-bar-simulator) - The macOS Touch Bar Simulator as a standalone app. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/touch-bar-simulator) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Added Storyboard -> SwiftUI Converter

<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md) 
1. [x] Project URL: https://swiftify.com/#/converter/storyboard2swiftui/
2. [x] Why should this project be added: This project converts storyboard and xibs to SwiftUI, this tool is quite relevant as many developers are looking for a way to port their UI code to SwiftUI.
3. [x] End all descriptions with a full stop/period 
4. [x] Entry is ordered alphabetically 
5. [x] Appropriate icon(s) added if applicable (OSS, freeware) 

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->
