### PR TITLE
Added WorkspacePro to productivity apps' list

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
+- [WorkspacePro](https://workspaceproapp.com) - Launch/close a bunch of macOS apps, open URLs and files just with 1 shortcut or click!
 
 
 ### Sharing Files


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL:  https://workspaceproapp.com
2. [x] Why should this project be added: WorkspacePro is a native macOS app which allows users to launch a bunch of apps, files and also open URL addresses at the same time just with shortcuts or pressing the button in the menu bar. WorkspacePro featured in ProductHunt as [#1 Product of the Day](https://www.producthunt.com/posts/workspacepro)
3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->
