### PR TITLE
Remove Arthur

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,6 @@
 - [AnyBar](https://github.com/tonsky/AnyBar) - A menubar status indicator. [![Open-Source Software][OSS Icon]](https://github.com/tonsky/AnyBar) ![Freeware][Freeware Icon]
 - [APNGb](https://github.com/mancunianetz/APNGb) - .apng image assembler/disassembler app. [![Open-Source Software][OSS Icon]](https://github.com/mancunianetz/APNGb) ![Freeware][Freeware Icon]
 - [AppCleaner](http://freemacsoft.net/appcleaner/) - Uninstall your apps easily. ![Freeware][Freeware Icon]
-- [Arthur](http://arthur-osx.com/) - Safely optimize some of your Mac's hidden settings.
 - [Artify](https://github.com/NghiaTranUIT/artify-macos) - A macOS X application for bringing dedicatedly 18th century Arts to everyone. [![Open-Source Software][OSS Icon]](https://github.com/NghiaTranUIT/artify-macos) ![Freeware][Freeware Icon]
 - [Bartender](https://www.macbartender.com/) - Organize your menu bar apps.
 - [Batch Image Resizer](http://www.ironstarmedia.co.uk/resources/osx-image-resizer/) - Resize a large number of images quickly on your computer. ![Freeware][Freeware Icon]


### PR DESCRIPTION
http://arthur-osx.com doesn't seem to be up anymore

<img width="693" alt="Screen Shot 2020-08-08 at 2 12 16 PM" src="https://user-images.githubusercontent.com/4723115/89719830-3156c480-d981-11ea-94c3-94925192b0b5.png">

#123
#553