### PR TITLE
Add Privacy Redirect for Safari

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@
 - [OnyX](http://www.titanium.free.fr/) -  Multifunction utility to verify disks and files, run cleaning and system maintenance tasks, configure hidden options and more. ![Freeware][Freeware Icon]
 - [Paparazzi](http://derailer.org/paparazzi/) - A small utility that makes screenshots of webpages. ![Freeware][Freeware Icon]
 - [Paragon NTFS](http://www.paragon-drivers.com/ntfs-mac/) - World fastest NTFS driver.
+- [Privacy Redirect for Safari](https://github.com/smmr-software/privacy-redirect-safari) - A Safari extension that redirect sites to privacy friendly alternatives. [![Open-Source Software][OSS Icon]](https://github.com/smmr-software/privacy-redirect-safari)
 - [Radio Silence](https://radiosilenceapp.com) - Simple to use firewall and network monitor.
 - [Microsoft Remote Desktop Connection Client](https://itunes.apple.com/us/app/microsoft-remote-desktop/id715768417) - Remote Desktop Connection Client lets you connect from your Macintosh computer to a Windows-based computer.
 - [RDM](https://github.com/avibrazil/RDM) - Easily set Mac Retina display to higher unsupported resolutions. [![Open-Source Software][OSS Icon]](https://github.com/avibrazil/RDM)


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: https://github.com/smmr-software/privacy-redirect-safari
2. [x] Why should this project be added: Not only is Privacy Redirect an incredibly useful extension, which I myself use every day, it also serves as an example for others seeking to make web extensions for Safari. It uses the most up-to-date frameworks from Apple, including SwiftUI, and also includes a fairly novel method for communicating between extension and native app.
3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->
