### PR TITLE
Add ARHeadsetKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 ### Developers
 
 - [Anvil](http://anvilformac.com/) - Serve up static sites and Rack apps with simple URLs and zero configuration. ![Freeware][Freeware Icon]
+- [ARHeadsetKit](https://github.com/philipturner/ARHeadsetKit) - Optimization utility functions for a high-level AR framework, brought to the Mac. [![Open-Source Software][OSS Icon]](https://github.com/philipturner/ARHeadsetKit) ![Freeware][Freeware Icon]
 - [Base 2](http://menial.co.uk/base/) - A GUI for managing SQLite databases.
 - [Cakebrew](https://www.cakebrew.com/) - The Homebrew GUI App. [![Open-Source Software][OSS Icon]](https://github.com/brunophilipe/Cakebrew) ![Freeware][Freeware Icon]
 - [CocoaRestClient](https://mmattozzi.github.io/cocoa-rest-client) - An app for testing REST endpoints. [![Open-Source Software][OSS Icon]](https://github.com/mmattozzi/cocoa-rest-client) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@
 ### Developers
 
 - [Anvil](http://anvilformac.com/) - Serve up static sites and Rack apps with simple URLs and zero configuration. ![Freeware][Freeware Icon]
-- [ARHeadsetKit](https://github.com/philipturner/ARHeadsetKit) - Optimization utility functions for a high-level AR framework, brought to the Mac. [![Open-Source Software][OSS Icon]](https://github.com/philipturner/ARHeadsetKit) ![Freeware][Freeware Icon]
+- [ARHeadsetUtil](https://github.com/philipturner/ARHeadsetUtil) - Optimization utility functions for a high-level AR framework, brought to the Mac. [![Open-Source Software][OSS Icon]](https://github.com/philipturner/ARHeadsetUtil) ![Freeware][Freeware Icon]
 - [Base 2](http://menial.co.uk/base/) - A GUI for managing SQLite databases.
 - [Cakebrew](https://www.cakebrew.com/) - The Homebrew GUI App. [![Open-Source Software][OSS Icon]](https://github.com/brunophilipe/Cakebrew) ![Freeware][Freeware Icon]
 - [CocoaRestClient](https://mmattozzi.github.io/cocoa-rest-client) - An app for testing REST endpoints. [![Open-Source Software][OSS Icon]](https://github.com/mmattozzi/cocoa-rest-client) ![Freeware][Freeware Icon]


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: [https://github.com/philipturner/ARHeadsetKit](https://github.com/philipturner/ARHeadsetKit)
2. [x] Why should this project be added: Although this is geared toward iOS, it has several useful utility functions and types which can be bound to a Mac app under a separate framework. It includes a highly productive wrapper over MTLBuffer ([MTLLayeredBuffer](https://github.com/philipturner/ARHeadsetKit/blob/main/docs/articles/layered-buffer.md)), an API for experimenting with ray tracing, and convenient wrappers over the "simd" framework for optimizing math-intensive CPU operations and CPU-GPU communication. It also might be the only open-source framework with both inlinable Metal Shading Language functions and a live connection to GitHub like a Swift package (unlike [GPUImage3](https://github.com/BradLarson/GPUImage3), where you must copy the Xcode project from a ZIP file).
3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->
