### PR TITLE
Remove SoundCleod App, close #623

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,6 @@
 - [Clocker](https://itunes.apple.com/us/app/clocker-menubar-world-clock/id1056643111?ls=1&mt=12) - Check time in multiple timezones from your Mac menubar. [![Open-Source Software][OSS Icon]](https://github.com/Abhishaker17/Clocker) ![Freeware][Freeware Icon]
 - [Juice](https://github.com/brianmichel/Juice) - Make your battery information a bit more interesting. [![Open-Source Software][OSS Icon]](https://github.com/brianmichel/Juice) ![Freeware][Freeware Icon]
 - [Sonora](https://github.com/sonoramac/Sonora) -  A minimal, beautifully designed music player. [![Open-Source Software][OSS Icon]](https://github.com/sonoramac/Sonora) ![Freeware][Freeware Icon]
-- [SoundCleod](http://soundcleod.com/) - A browser for SoundCloud. [![Open-Source Software][OSS Icon]](https://github.com/salomvary/soundcleod) ![Freeware][Freeware Icon]
 - [Spillo](https://bananafishsoftware.com/products/spillo/) - Powerful, beautiful and fast Pinboard client.
 - [Transmit](https://panic.com/transmit/) - A FTP client.
 


### PR DESCRIPTION
As [**@JihunDev**](https://github.com/JihunDev) [noted](https://github.com/iCHAIT/awesome-macOS/issues/623#issue-1490782558), the
> SoundCleod domain expired on 2022-05-05. Also, the project is no longer managed.
> 
> See the SoundCleod Repository: [soundcleod](https://github.com/salomvary/soundcleod)

and merging this pull request will fix #623.