### PR TITLE
Guideline: commercial apps offer trial

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -13,6 +13,7 @@ Please ensure your pull request adheres to the following guidelines:
 - Make sure your text editor is set to remove trailing whitespace.
 - All open source applications should have the [OSS symbol](https://github.com/iCHAIT/awesome-osx/blob/master/media/oss.svg), the primary link for the application should point to the application's website and the OSS symbol should link to the source code. In case the application does not have any website then both the links should point to the source code.
 - All applications that are free and do not charge any money whatsoever should have the [Freeware symbol](https://github.com/iCHAIT/awesome-osx/blob/master/media/free.svg).
+- Commercial applications should offer a free trial for maintainers to validate inclusion to the list. Free trials as part of a bundle/service like SetApp do not count.
 - Sensible new categories or improvements to the existing categorization are welcome. Please ask the maintainers if in doubt.
 - [No Electron](https://github.com/iCHAIT/awesome-macOS/pull/368) apps :no_good:
 - Be prepared for criticism, don't feel entitled and keep an open mind.


### PR DESCRIPTION
Lots of PRs lately are from authors of commercial applications. There is no clear action to take if contributors cannot try out these applications. Adding a guideline makes explicit the need for validation.

See #628