### PR TITLE
Add pgMagic

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@
 - [Medis](https://getmedis.com) - A modern GUI for Redis.
 - [Pasteboard Viewer](https://apps.apple.com/app/id1499215709) - Inspect the system pasteboards. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/Pasteboard-Viewer) ![Freeware][Freeware Icon]
 - [Paw](https://luckymarmot.com/paw) - The ultimate REST client.
-- [PgMagic](https://pgmagic.app/?ref=awesomemacos) - A Postgres client that lets you talk to your db in SQL or natural language.
+- [pgMagic](https://pgmagic.app/?ref=awesomemacos) - A PostgreSQL client that lets you talk to your database in SQL or natural language.
 - [Pods Updater](https://github.com/kizitonwose/PodsUpdater) - A macOS app which helps you manage dependency releases in your Podfile. [![Open-Source Software][OSS Icon]](https://github.com/kizitonwose/PodsUpdater) ![Freeware][Freeware Icon]
 - [Postico](https://eggerapps.at/postico/) - A modern PostgreSQL client.
 - [Postgres.app](http://postgresapp.com/) - The easiest way to get started with PostgreSQL. [![Open-Source Software][OSS Icon]](https://github.com/PostgresApp/PostgresApp) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@
 - [Medis](https://getmedis.com) - A modern GUI for Redis.
 - [Pasteboard Viewer](https://apps.apple.com/app/id1499215709) - Inspect the system pasteboards. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/Pasteboard-Viewer) ![Freeware][Freeware Icon]
 - [Paw](https://luckymarmot.com/paw) - The ultimate REST client.
-- [pgMagic](https://pgmagic.app/?ref=awesomemacos) - A PostgreSQL client that lets you talk to your database in SQL or natural language.
+- [pgMagic](https://pgmagic.app) - A PostgreSQL client that lets you talk to your database in SQL or natural language.
 - [Pods Updater](https://github.com/kizitonwose/PodsUpdater) - A macOS app which helps you manage dependency releases in your Podfile. [![Open-Source Software][OSS Icon]](https://github.com/kizitonwose/PodsUpdater) ![Freeware][Freeware Icon]
 - [Postico](https://eggerapps.at/postico/) - A modern PostgreSQL client.
 - [Postgres.app](http://postgresapp.com/) - The easiest way to get started with PostgreSQL. [![Open-Source Software][OSS Icon]](https://github.com/PostgresApp/PostgresApp) ![Freeware][Freeware Icon]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@
 - [Medis](https://getmedis.com) - A modern GUI for Redis.
 - [Pasteboard Viewer](https://apps.apple.com/app/id1499215709) - Inspect the system pasteboards. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/Pasteboard-Viewer) ![Freeware][Freeware Icon]
 - [Paw](https://luckymarmot.com/paw) - The ultimate REST client.
+- [PgMagic](https://pgmagic.app/?ref=awesomemacos) - A Postgres client that lets you talk to your db in SQL or natural language.
 - [Pods Updater](https://github.com/kizitonwose/PodsUpdater) - A macOS app which helps you manage dependency releases in your Podfile. [![Open-Source Software][OSS Icon]](https://github.com/kizitonwose/PodsUpdater) ![Freeware][Freeware Icon]
 - [Postico](https://eggerapps.at/postico/) - A modern PostgreSQL client.
 - [Postgres.app](http://postgresapp.com/) - The easiest way to get started with PostgreSQL. [![Open-Source Software][OSS Icon]](https://github.com/PostgresApp/PostgresApp) ![Freeware][Freeware Icon]


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: https://pgmagic.app
2. [x] Why should this project be added: pgMagic is a small (14mb) mac postgres client that lets you do anything you would expect from a regular db gui, but also lets you query postgres in natural language. Its super helpful for data and business analysts that have some understanding of SQL, but don't want to craft custom queries for every minor question asked of them. Its also very helpful for people new to SQL to get a basic query up for them to edit and alter. Being a mac app, no db credentials are sent to a third party server and are kept locally on your machine. Personally I have found it extremely valuable in quickly gaining insights into user actions that are somewhere in my db but not easily accessible and would require a relatively hefty query to obtain (saving me 10 to 15 minutes).
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->
