### PR TITLE
Add Lasso - window manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@
 - [Divvy Window Manager](http://mizage.com/divvy/) - Window management for tiling your windows.
 - [Hammerspoon](http://www.hammerspoon.org/) - Extremely powerful scripting engine for macOS. [![Open-Source Software][OSS Icon]](https://github.com/Hammerspoon/hammerspoon) ![Freeware][Freeware Icon]
 - [Hummingbird](https://hummingbirdapp.site/) - Easily move and resize windows without mouse clicks, from anywhere within a window.
+- [Lasso](https://thelasso.app/) - Grid-based intuitive window manager for macOS.
 - [Moom](https://manytricks.com/moom/) - Move and zoom windows, super light weight and customizable.
 - [Phoenix](https://github.com/kasper/phoenix) - A lightweight window and app manager scriptable with JavaScript. [![Open-Source Software][OSS Icon]](https://github.com/Hammerspoon/hammerspoon) ![Freeware][Freeware Icon]
 - [Rectangle](https://rectangleapp.com/) - Easily organize windows without using a mouse. [![Open-Source Software][OSS Icon]](https://github.com/rxhanson/Rectangle) ![Freeware][Freeware Icon]


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: https://thelasso.app/
2. [x] Why should this project be added: The app implements an easy-to-use grid-based approach for window management. It's maintained (new updates coming almost every month), native, and supports macOS 12 - macOS 14 Sonoma.
3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->
