### PR TITLE
Add Wokabulary app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
     - [Developers](#developers)
     - [E-Book Utilities](#e-book-utilities)
     - [Editors](#editors)
+    - [Education](#education)
     - [Email Utilities](#email-utilities)
     - [Finder](#finder)
     - [Games](#games)
@@ -143,6 +144,11 @@
 - [Sublime Text 3](http://www.sublimetext.com/) - The sophisticated text editor.
 - [TextMate](https://macromates.com/) - A graphical text editor. [![Open-Source Software][OSS Icon]](https://github.com/textmate/textmate)
 - [VimR](http://vimr.org) - Vim, refined. [![Open-Source Software][OSS Icon]](https://github.com/qvacua/vimr) ![Freeware][Freeware Icon]
+
+
+### Education
+
+- [Wokabulary](https://wokabulary.com) - Flash card app for collecting and learning foreign language words.
 
 
 ### Email Utilities


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: https://wokabulary.com
2. [x] Why should this project be added: 

Wokabulary is a flash card learning app for everybody learning a foreign language in school, evening class, or in self-study. It is a native Mac app written in pure Swift and SwiftUI. It fully integrates into the Apple ecosystem with iCloud syncing, interactive widgets, and also runs on iPad and iPhone. It has a wide user base and has been featured as App of the Day by Apple in September 2023.

4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

Note:
This also adds a new category "Education" as Wokabulary didn't seem to fit into any of the existing categories and there are potentially many more educational apps to be added in the future.
