### PR TITLE
Add ChromeBuddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@
 - [BitBar](https://github.com/matryer/bitbar) - Display output of any script to the menu bar. [![Open-Source Software][OSS Icon]](https://github.com/matryer/bitbar) ![Freeware][Freeware Icon]
 - [Burn](http://burn-osx.sourceforge.net/Pages/English/home.html) - No-nonsense burning of Data/Audio/Video CDs and DVDs, including copying. [![Open-Source Software][OSS Icon]](https://sourceforge.net/p/burn-osx/code-git/ci/master/tree/) ![Freeware][Freeware Icon]
 - [CheatSheet](https://www.cheatsheetapp.com/CheatSheet/) - Know your short cuts. ![Freeware][Freeware Icon]
+- [ChromeBuddy](https://github.com/AndreyGr/ChromeBuddy) - An app that allows to open external links in foremost(top) Chrome browser window(including incognito windows) ![Open-Source Software][OSS Icon] ![Freeware][Freeware Icon]
 - [ClipboardCleaner](https://github.com/Zuehlke/Clipboard_Cleaner) - Automatically removes text formatting from the clipboard. [![Open-Source Software][OSS Icon]](https://github.com/Zuehlke/Clipboard_Cleaner) ![Freeware][Freeware Icon]
 - [CommandQ](https://clickontyler.com/commandq/) - Never accidentally quit an app again.
 - [ControlPlane](http://www.controlplaneapp.com/) - Automate running tasks based on where you are or what you do. [![Open-Source Software][OSS Icon]](https://github.com/dustinrue/ControlPlane) ![Freeware][Freeware Icon]


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: https://github.com/AndreyGr/ChromeBuddy
2. [x] Why should this project be added: ChromeBuddy is tiny app that is set as default browser and allows to open external links in Chrome's top window not matter if it is incognito or common window(the default Chrome behaviour does not allow to open external links in incognito window). Overall this application addressing the following fix in Chromium engine: https://issues.chromium.org/issues/40536115 that is changed original behaviour which this app is intended to replicate. The motivation of adding this app is fare amount of users as me that complaining on the change in Chrome behaviour and looking for solution to revert original behaviour.
3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->
