### PR TITLE
Removed mailplane.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,6 @@
 
 - [Airmail](http://airmailapp.com/) - Lightning fast email client designed for El Capitan.
 - [MailMate](https://freron.com/) - Advanced IMAP email client, featuring extensive keyboard control and Markdown support.
-- [Mailplane](https://mailplaneapp.com/) - A tightly integreted client for Google Mail, Inbox, Calender, and Contacts.
-
 
 ### Finder
 


### PR DESCRIPTION
Mailplane is no longer available due to changes in Google's authentication page modifications.

See:
https://mailplaneapp.com/blog/entry/mailplane_stopped_selling_licenses.html

<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [ ] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [ ] Project URL:
2. [ ] Why should this project be added:
3. [ ] End all descriptions with a full stop/period
4. [ ] Entry is ordered alphabetically
5. [ ] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->
