### PR TITLE
Add Magic Switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@
 - [Keyboard Maestro](http://www.keyboardmaestro.com) - Automate routine actions based on triggers from keyboard, menu, location, added devices, and more.
 - [Keytty](http://keytty.com) - Enables you to control your mouse with a few key strokes. Mouse Keys Alternative.
 - [LaunchBar](https://www.obdev.at/products/launchbar/index.html) - Start applications, navigate folders, manipulate files, control your Mac and much more just by using the keyboard.
+- [Magic Switch](https://magic-switch.com/) - Switch your Magic Keyboard, Magic Mouse and Magic Trackpad between multiple Macs with different Apple IDs.
 - [MeetingBar](https://meetingbar.onrender.com) - Your meetings in MacOS status bar [![Open-Source Software][OSS Icon]](https://github.com/leits/MeetingBar) ![Freeware][Freeware Icon]
 - [MenubarX](https://MenubarX.app) - A powerful menu bar browser.
 - [OmniFocus](https://www.omnigroup.com/omnifocus) - An incredible task management platform for Mac, iPad, and iPhone.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL: https://magic-switch.com
2. [x] Why should this project be added: **Magic Switch** is a menu bar mac app that lets you switch your Magic Keyboard, Mouse & Trackpad between multiple Mac devices with different Apple IDs. It lets you fully transfer the connection of your peripherals from one device to the other without requiring you to go to Bluetooth Settings each time and forgetting each device then going to the second machine and pairing them one by one. Instead, it is simplified into a single click of a button. The app also offers a couple more cool features like using keyboard shortcuts and transfering pieces of text between Macs via the Magic Keyboard.
3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)
