### PR TITLE
Add `app-menu` to the `Productivity`

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@
 ### Productivity
 
 - [Alfred](https://www.alfredapp.com/) - Boosts your efficiency and productivity.
+- [app-menu](https://github.com/barseghyanartur/app-menu/) - The missing Applications Menu for macOS. [![Open-Source Software][OSS Icon]](https://github.com/barseghyanartur/app-menu/) ![Freeware][Freeware Icon]
 - [BetterTouchTool](https://folivora.ai) - Configure gestures for mouse and actions for keyboard shortcuts.
 - [ClipMenu](http://www.clipmenu.com/) - ClipBoard History Manager. [![Open-Source Software][OSS Icon]](https://github.com/naotaka/ClipMenu) ![Freeware][Freeware Icon]
 - [CloudClip](http://www.thinkbitz.com/cloudclip/) - Sync your clipboard between your Mac and your iOS devices. ![Freeware][Freeware Icon]


### PR DESCRIPTION
Added `app-menu`, the missing Applications Menu for macOS, to the `Productivity` section. 

https://github.com/barseghyanartur/app-menu/

<!-- Thanks for contributing to awesome-macOS  -->

<!-- Please fill out the following: -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] Project URL:
2. [x] Why should this project be added: It's a useful add-on, that I as Linux user missed on macOS.
3. [x] End all descriptions with a full stop/period
4. [x] Entry is ordered alphabetically
5. [x] Appropriate icon(s) added if applicable (OSS, freeware)

<!--

Again, please read https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md if you didn't yet.

-->
