### PR TITLE
Add Bosun to Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
 
 - [Anvil](http://anvilformac.com/) - Serve up static sites and Rack apps with simple URLs and zero configuration. ![Freeware][Freeware Icon]
 - [Base 2](http://menial.co.uk/base/) - A GUI for managing SQLite databases.
+- [Bosun](https://bosun.dev) - Menu bar app that shows every open port, tunnel, VPN connection, and Docker container mapped to its process.
 - [CocoaRestClient](https://mmattozzi.github.io/cocoa-rest-client) - An app for testing REST endpoints. [![Open-Source Software][OSS Icon]](https://github.com/mmattozzi/cocoa-rest-client) ![Freeware][Freeware Icon]
 - [Cork](https://corkmac.app) - A fast, intuitive Homebrew GUI [![Open-Source Software][OSS Icon]](https://github.com/buresdv/Cork)
 - [Dash](https://kapeli.com/dash) - An API Documentation Browser and Code Snippet Manager.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software — Bosun has no AI/LLM component; it's a native menu bar tool for monitoring listening ports, tunnels, VPNs, and Docker containers.
2. [x] Project URL: https://bosun.dev
3. [x] Why should this project be added: Bosun is a native macOS menu bar app that shows every open port, tunnel (ngrok/Cloudflare), VPN connection, and Docker container mapped to its process, with one-click kill. There isn't an existing entry in the Developers section covering this exact port/process visibility use case.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (between "Base 2" and "CocoaRestClient" in Developers)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) — neither applies: Bosun is closed-source and commercial. It offers a genuine 14-day free trial directly (not bundled via SetApp), per the guideline for commercial apps.

(Reopening as a fresh PR since the original, #902, was closed and locked for skipping this template — content is unchanged.)
