### PR TITLE
Add Gatterie

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@
 ### Finder
 
 - [ForkLift](https://itunes.apple.com/us/app/forklift-file-manager-ftp/id412448059) - File Manager and FTP/SFTP/WebDAV/Amazon S3 client.
+- [Gatterie](https://gatterie.fallgatter.info) - Visual file library for your existing folders, previewing 128 formats including RAW, documents and 3D/CAD.
 - [Path Finder](http://www.cocoatech.com/pathfinder/) - A powerful dual-pane browser alternative to Finder.
 - [Pathly](https://pathly.sophinauta.com/) - Copy any file or folder path from Finder: full, directory, URL, or Git-relative.
 - [Quicklook-Plugins](https://github.com/sindresorhus/quick-look-plugins) - List of extra quicklook plugins to enable previewing more filetypes in the Finder.


### PR DESCRIPTION
Adds Gatterie, a visual file library for macOS that previews 128 file formats — photos, RAW, documents, video, creative files, source code and 3D/CAD — directly from existing folders, without importing or moving anything.

Website: https://gatterie.fallgatter.info

The entry is added in alphabetical order in the relevant section, following the existing formatting.