### PR TITLE
Add OpenClip to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@
 - [NoteGen](https://notegen.top/) - Local-first Markdown notes app with capture, editing, file management, canvas, and optional sync. [![Open-Source Software][OSS Icon]](https://github.com/codexu/note-gen)
 - [OmniFocus](https://www.omnigroup.com/omnifocus) - An incredible task management platform for Mac, iPad, and iPhone.
 - [OmniOutliner](https://www.omnigroup.com/omnioutliner/) - Perfect for collecting information, outlining ideas, adding structure to any sort of writing, and much more.
+- [OpenClip](https://getopenclip.app) - Lightweight floating action bar that turns selected text into instant actions. [![Open-Source Software][OSS Icon]](https://github.com/ganeshmshetty/openclip) ![Freeware][Freeware Icon]
 - [Pandan](https://apps.apple.com/app/id1569600264) - Time awareness in your menu bar. ![Freeware][Freeware Icon]
 - [Paste](http://pasteapp.me) - The new way to copy & paste for Mac.
 - [PasteClip](https://github.com/minsang-alt/PasteClip) - Free Paste-like clipboard manager with pinboards, Quick Look previews, and one-click copying. [![Open-Source Software][OSS Icon]](https://github.com/minsang-alt/PasteClip) ![Freeware][Freeware Icon]


### PR DESCRIPTION
### Summary
Add **OpenClip** to the Productivity section.

- **Name**: OpenClip
- **Description**: Lightweight floating action bar for macOS that turns selected text into instant actions.
- **License**: MIT (Open Source)
- **Website**: https://getopenclip.app
- **Repository**: https://github.com/ganeshmshetty/openclip