### PR TITLE
Add Mac Classic Player to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@
 
 - [HandBrake](https://handbrake.fr/) - High performance video encoding and conversion tools with a nice GUI. [![Open-Source Software][OSS Icon]](https://github.com/HandBrake/HandBrake)
 - [IINA](https://lhc70000.github.io/iina/) - Media player with a minimalist design. [![Open-Source Software][OSS Icon]](https://github.com/lhc70000/iina) ![Freeware][Freeware Icon]
+- [Mac Classic Player](https://mcp.kkweb.io/) - Media player driven by the keyboard, in the spirit of Media Player Classic. [![Open-Source Software][OSS Icon]](https://github.com/piro0919/mac-classic-player) ![Freeware][Freeware Icon]
 - [mpv](https://mpv.io/) - Media player. [![Open-Source Software][OSS Icon]](https://github.com/mpv-player/mpv)
 - [ScreenFlow](http://www.telestream.net/screenflow/) - Screencasting and video editing software.
 - [Subler](https://bitbucket.org/galad87/subler/wiki/Home) - Mux and tag MP4 files. [![Open-Source Software][OSS Icon]](https://bitbucket.org/galad87/subler/wiki/Home) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/piro0919/mac-classic-player
3. [x] Why should this project be added: The Video section has good players already, but none of them are trying to feel like Media Player Classic did on Windows — open a file, it plays, and the keyboard does the work instead of the menus. That's the whole reason this one exists. It's built with Tauri, not Electron, MIT licensed and free, with no AI anything in it.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

I'm the author, so take that for what it's worth. Happy to reword if the description doesn't fit the list.