### PR TITLE
Add Mekuri to E-Book Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
 ### E-Book Utilities
 
 - [Kindle App](http://www.amazon.com/gp/help/customer/display.html?nodeId=201246110) - Amazon Kindle App for macOS.
+- [Mekuri](https://mekuri.kkweb.io/) - Local comic and manga reader for CBZ, CBR, and image folders. [![Open-Source Software][OSS Icon]](https://github.com/piro0919/mekuri) ![Freeware][Freeware Icon]
 
 
 ### Editors


### PR DESCRIPTION
Mekuri is a lightweight local comic and manga reader for macOS. It opens CBZ, CBR and image folders, with spread view and right-to-left reading for manga.

- Site: https://mekuri.kkweb.io/
- Source: https://github.com/piro0919/mekuri (MIT)
- Free, open source, macOS 14+ (Apple silicon)