### PR TITLE
Add LeafyApp to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@
 - [Keyty](https://keyty.app) - Keystroke and mouse-click visualizer for demos, screen recordings, presentations, and livestreams. [![Open-Source Software][OSS Icon]](https://github.com/keytyapp/Keyty) ![Freeware][Freeware Icon]
 - [Keytty](http://keytty.com) - Enables you to control your mouse with a few key strokes. Mouse Keys Alternative.
 - [LaunchBar](https://www.obdev.at/products/launchbar/index.html) - Start applications, navigate folders, manipulate files, control your Mac and much more just by using the keyboard.
-- [Leafy](https://leafyapp.uk) - Look up any word on screen with a keyboard shortcut and save it with the sentence you found it in. ![Freeware][Freeware Icon]
+- [LeafyApp](https://leafyapp.uk) - Look up any word on screen with a keyboard shortcut and save it with the sentence you found it in. ![Freeware][Freeware Icon]
 - [Mac Mouse Fixer](https://www.macfix.click/) - Fixes accidental double-clicks and adds smooth scrolling, horizontal scrolling, and wheel zoom for external mice.
 - [MeetingBar](https://meetingbar.onrender.com) - Your meetings in MacOS status bar [![Open-Source Software][OSS Icon]](https://github.com/leits/MeetingBar) ![Freeware][Freeware Icon]
 - [MenubarX](https://MenubarX.app) - A powerful menu bar browser.

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@
 - [Keyty](https://keyty.app) - Keystroke and mouse-click visualizer for demos, screen recordings, presentations, and livestreams. [![Open-Source Software][OSS Icon]](https://github.com/keytyapp/Keyty) ![Freeware][Freeware Icon]
 - [Keytty](http://keytty.com) - Enables you to control your mouse with a few key strokes. Mouse Keys Alternative.
 - [LaunchBar](https://www.obdev.at/products/launchbar/index.html) - Start applications, navigate folders, manipulate files, control your Mac and much more just by using the keyboard.
+- [Leafy](https://leafyapp.uk) - Look up any word on screen with a keyboard shortcut and save it with the sentence you found it in. ![Freeware][Freeware Icon]
 - [Mac Mouse Fixer](https://www.macfix.click/) - Fixes accidental double-clicks and adds smooth scrolling, horizontal scrolling, and wheel zoom for external mice.
 - [MeetingBar](https://meetingbar.onrender.com) - Your meetings in MacOS status bar [![Open-Source Software][OSS Icon]](https://github.com/leits/MeetingBar) ![Freeware][Freeware Icon]
 - [MenubarX](https://MenubarX.app) - A powerful menu bar browser.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://leafyapp.uk
3. [x] Why should this project be added:

Leafy is a native macOS menu bar app for people who read in a foreign language. You box any word on screen with a keyboard shortcut, and it saves that word together with the sentence you found it in, building a vocabulary list as you read. Saved words can be reviewed later with the word blanked out of its original sentence.

Because it reads the screen rather than the text selection, it works on things a dictionary extension or a text-selection popup cannot reach: PDFs, scanned textbooks, video subtitles, images.

On the "AI"-adjacent point, so you can judge it rather than take my word: word and sentence recognition is on-device OCR, and definitions can be served by downloadable offline dictionaries with no network at all. Definitions can also be fetched from a hosted model to fit the sentence the word appeared in, which is the default. If that crosses the line for this list, I understand the close.

Free, native Swift, not Electron.

4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (freeware)
