### PR TITLE
Add crterm to Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@
 
 ### Terminal
 
+- [crterm](https://crterm.ai) - Beautifully opinionated terminal emulator, with advanced session navigation and GPU-accelerated retro presets. [![Open-Source Software][OSS Icon]](https://github.com/mbcltd/CRTerminal) ![Freeware][Freeware Icon]
 - [iTerm 2](https://www.iterm2.com/) - A terminal emulator. [![Open-Source Software][OSS Icon]](https://github.com/gnachman/iTerm2) ![Freeware][Freeware Icon]
 
 


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://crterm.ai (source: https://github.com/mbcltd/CRTerminal)
3. [x] Why should this project be added: crterm is a free, open-source (Apache 2.0), fully native macOS terminal emulator (AppKit + Metal, no Electron) with GPU-accelerated rendering, advanced session navigation (⌘K palette across sessions, searchable command history, split panes, tear-off windows), and retro CRT presets modelled on historic monitors, including a degauss button. It ships as a signed/notarised DMG with auto-updates and is actively developed. It broadens the Terminal category, which currently lists a single app.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)