### PR TITLE
Add Tracexy to Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@
 - [TopOff](https://github.com/ihazgithub/TopOff) - Menu bar app for Homebrew — full beer mug when packages are fresh, half mug when it's time to refill. [![Open-Source Software][OSS Icon]](https://github.com/ihazgithub/TopOff) ![Freeware][Freeware Icon]
 - [Touch Bar Simulator](https://github.com/sindresorhus/touch-bar-simulator) - The macOS Touch Bar Simulator as a standalone app. [![Open-Source Software][OSS Icon]](https://github.com/sindresorhus/touch-bar-simulator) ![Freeware][Freeware Icon]
 - [Tower](https://www.git-tower.com/) - The most powerful Git client.
+- [Tracexy](https://rockxy.io/tracexy) - Native, local-first network intelligence for investigating live traffic and PCAP or PCAPNG captures as app-aware sessions. [![Open-Source Software][OSS Icon]](https://github.com/RockxyApp/Tracexy)
 - [Trailer](https://ptsochantaris.github.io/trailer/) - Configurable menubar Git notifications with accompanying native iOS app. [![Open-Source Software][OSS Icon]](https://github.com/ptsochantaris/trailer)
 - [Unused](https://jeffhodnett.github.io/Unused/) - An app for checking Xcode projects for unused resources. [![Open-Source Software][OSS Icon]](https://github.com/jeffhodnett/Unused) ![Freeware][Freeware Icon]
 - [Vagrant Manager](http://vagrantmanager.com) - Manage your vagrant machines in one place with Vagrant Manager for macOS. [![Open-Source Software][OSS Icon]](https://github.com/lanayotech/vagrant-manager/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software. Tracexy is not an AI prompt wrapper; its primary purpose is local network capture and investigation.
2. [x] Project URL: https://rockxy.io/tracexy
3. [x] Why should this project be added: Tracexy is a native SwiftUI/AppKit macOS network intelligence app that passively captures live traffic or opens PCAP and PCAPNG files, then organizes the evidence into app-aware sessions. It adds a local-first complement to the HTTP debugging tools already listed in Developers, with public AGPL-3.0-or-later source and a signed, notarized release.
4. [x] End all descriptions with a full stop/period.
5. [x] Entry is ordered alphabetically between Tower and Trailer in Developers.
6. [x] Appropriate icon added: the OSS icon links to the source repository. The Freeware icon is deliberately omitted because Tracexy offers paid licenses alongside its Community tier.

Disclosure: I am a Tracexy maintainer.