### PR TITLE
Add Metrune

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@
 - [Mac Mouse Fixer](https://www.macfix.click/) - Fixes accidental double-clicks and adds smooth scrolling, horizontal scrolling, and wheel zoom for external mice.
 - [MeetingBar](https://meetingbar.onrender.com) - Your meetings in MacOS status bar [![Open-Source Software][OSS Icon]](https://github.com/leits/MeetingBar) ![Freeware][Freeware Icon]
 - [MenubarX](https://MenubarX.app) - A powerful menu bar browser.
+- [Metrune](https://treafree.github.io/Metrune/en/) - Local-first focus workspace that brings tasks, coding activity, device events, badges, and reports into the MacBook notch. ![Freeware][Freeware Icon]
 - [NoteGen](https://notegen.top/) - Local-first Markdown notes app with capture, editing, file management, canvas, and optional sync. [![Open-Source Software][OSS Icon]](https://github.com/codexu/note-gen)
 - [OmniFocus](https://www.omnigroup.com/omnifocus) - An incredible task management platform for Mac, iPad, and iPhone.
 - [OmniOutliner](https://www.omnigroup.com/omnioutliner/) - Perfect for collecting information, outlining ideas, adding structure to any sort of writing, and much more.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://treafree.github.io/Metrune/en/
3. [x] Why should this project be added: Metrune is a native, local-first focus workspace that brings tasks, coding and GitHub activity, device events, badges, and reports into the MacBook notch. Its primary purpose is focus and activity tracking; it is not an AI prompt wrapper, chatbot, agent, or code-generation client. Optional Codex integration reads local status and quota metadata and does not submit prompts or source code.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

The current community release is free, so the Freeware icon is included. The source is visible under PolyForm Noncommercial 1.0.0, which is not OSI-approved, so the OSS icon is intentionally omitted. Metrune is written in Swift/SwiftUI and is not an Electron app.