### PR TITLE
Add OneTake to Sharing Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@
 - [Jumpshare](https://itunes.apple.com/us/app/jumpshare/id889922906) - Real-time file sharing app with support for instantly sharing code / Markdown, annotating screenshots, screen recording, and voice recording. ![Freeware][Freeware Icon]
 - [mac2imgur](https://github.com/mileswd/mac2imgur) - Upload images and screenshots to Imgur. [![Open-Source Software][OSS Icon]](https://github.com/mileswd/mac2imgur) ![Freeware][Freeware Icon]
 - [Monosnap](https://monosnap.com) - Annotate and upload images and screenshots, supports many backends like S3, SFTP, WebDAV, Dropbox, etc. ![Freeware][Freeware Icon]
+- [OneTake](https://chromewebstore.google.com/detail/onetake-screen-recording/khmkeidanahmnggpgepdlflpokipdbih) - Chrome extension that records a browser tab and copies a share link to the clipboard once the upload finishes. No account; recordings are capped at 5 minutes on the free tier, CA$6/mo lifts it to 10 minutes and 1080p.
 - [Transmission](https://www.transmissionbt.com/) - Simple, lightweight, multi-platform torrent client. [![Open-Source Software][OSS Icon]](https://github.com/transmission/transmission) ![Freeware][Freeware Icon]
 
 


### PR DESCRIPTION
Adding OneTake to **Sharing Files**, next to CloudApp, Jumpshare and Monosnap — same job (capture, then hand someone a link), different mechanism: it uploads while you are still recording, so the share link is on the clipboard when the recording stops rather than after an export.

Disclosure: I built it. Happy to move it to **Video** or drop the PR if a Chrome extension is out of scope for the list — Jumpshare and CloudApp are in this section for the same share-a-capture workflow, which is why I put it here.

Listing: https://chromewebstore.google.com/detail/onetake-screen-recording/khmkeidanahmnggpgepdlflpokipdbih

Entry placed alphabetically between Monosnap and Transmission.