### PR TITLE
Add Tidy app to productivity tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@
 - [TaskPaper](https://www.taskpaper.com/) - Plain text to-do lists.
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
+- [Tidy](https://tidymacapp.com) - Menu bar app that names files by reading what is inside them with on-device OCR, keeps Downloads and the Desktop organised with rules, and searches inside scanned PDFs. Never deletes, everything undoes.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
 
 


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://tidymacapp.com
3. [x] Why should this project be added: It reads what is written inside images and PDFs with on-device OCR and names each file from its contents, which nothing else in the Productivity section does. On the AI guideline: this is the allowed case, local specialised models (Vision OCR, and Apple's on-device model behind a strict check) as one step of a file-organising pipeline, not an interface to generative tools. Native Swift, no Electron. It is paid with no public trial; I will gladly provide a review licence to the maintainers for validation, just ask.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) — none apply, paid and closed source