### PR TITLE
Add Tomatino to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
+- [Tomatino](https://tomatino.app) - Menu bar Pomodoro timer that switches your Focus mode and your music with each session. [![Open-Source Software][OSS Icon]](https://github.com/missaq/tomatino) ![Freeware][Freeware Icon]
 
 
 ### Sharing Files


### PR DESCRIPTION
Tomatino is a Pomodoro timer for the macOS menu bar. Starting a session turns on a Focus mode and starts your music (Apple Music, Spotify, or a local folder it plays itself); the break turns both off again.

- Repository: https://github.com/missaq/tomatino
- Website: https://tomatino.app
- MIT licensed, free, no account and no telemetry
- Swift/SwiftUI, requires macOS 26 on Apple silicon

Added in alphabetical order under Productivity.