### PR TITLE
Add noswoosh to Window Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@
 - [Hammerspoon](http://www.hammerspoon.org/) - Extremely powerful scripting engine for macOS. [![Open-Source Software][OSS Icon]](https://github.com/Hammerspoon/hammerspoon) ![Freeware][Freeware Icon]
 - [Hummingbird](https://hummingbirdapp.site/) - Easily move and resize windows without mouse clicks, from anywhere within a window.
 - [Moom](https://manytricks.com/moom/) - Move and zoom windows, super light weight and customizable.
+- [noswoosh](https://github.com/mmathys/noswoosh) - Instant, animation-free switching between macOS Spaces with a 3-finger swipe or Ctrl+arrow keys. [![Open-Source Software][OSS Icon]](https://github.com/mmathys/noswoosh) ![Freeware][Freeware Icon]
 - [Phoenix](https://github.com/kasper/phoenix) - A lightweight window and app manager scriptable with JavaScript. [![Open-Source Software][OSS Icon]](https://github.com/Hammerspoon/hammerspoon) ![Freeware][Freeware Icon]
 - [Rectangle](https://rectangleapp.com/) - Easily organize windows without using a mouse. [![Open-Source Software][OSS Icon]](https://github.com/rxhanson/Rectangle) ![Freeware][Freeware Icon]
 - [ShiftPlus](https://shiftplus.app/) - macOS workspace manager to switch workspaces, restore apps and windows across Spaces, monitors, and Macs in one click.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/mmathys/noswoosh
3. [x] Why should this project be added: There is no other way to get instant (animation-free) switching between macOS Spaces without disabling SIP (yabai) or turning on system-wide Reduce Motion, which is a crossfade rather than an instant cut and affects every animation. noswoosh removes just the space-switch animation — the normal 3-finger swipe and Ctrl+←/→ keep working, they simply switch instantly. Native Swift (one file, no Electron, no AI), MIT-licensed, signed + notarized releases, installable via Homebrew cask. Disclosure: I'm the author.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (between Moom and Phoenix)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware): both, and since noswoosh has no separate website, both links point to the source code per the guidelines