### PR TITLE
Add Soju (free Battle.net / D2R / Steam on Apple Silicon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@
 - [Dolphin](https://dolphin-emu.org) - A powerful, Open Source emulator for Nintendo GameCube and Wii games. [![Open-Source Software][OSS Icon]](https://github.com/dolphin-emu/dolphin) ![Freeware][Freeware Icon]
 - [OpenEmu](http://openemu.org/) - Multiple Video Game System. [![Open-Source Software][OSS Icon]](https://github.com/OpenEmu/OpenEmu) ![Freeware][Freeware Icon]
 - [Screentendo](http://aaronrandall.com/blog/screentendo/) - Turn your screen into a playable level of Mario. [![Open-Source Software][OSS Icon]](https://github.com/AaronRandall/Screentendo) ![Freeware][Freeware Icon]
+- [Soju](https://github.com/BCD1210/soju) - Run Battle.net, Diablo II: Resurrected and Steam games with free GPL Wine and Apple’s Game Porting Toolkit. [![Open-Source Software][OSS Icon]](https://github.com/BCD1210/soju) ![Freeware][Freeware Icon]
 - [Stockfish](http://stockfishchess.org/mac/) - Beautiful, powerful chess application. [![Open-Source Software][OSS Icon]](https://github.com/daylen/stockfish-mac) ![Freeware][Freeware Icon]
 
 


### PR DESCRIPTION
Adds [Soju](https://github.com/BCD1210/soju) to the Games section (alphabetical order).

Soju is a free, GPL-licensed toolchain that runs Battle.net, Diablo II: Resurrected and the Windows Steam client (incl. D3D11 games via DXMT) on Apple Silicon — built from CodeWeavers' published Wine sources plus Apple's Game Porting Toolkit, no CrossOver purchase needed. Verified end-to-end on an M4 Pro / macOS 26: installer, Battle.net login, D2R in-game, Steam client + a Unity D3D11 title rendering in-game.

- Open source: GPL-3.0, https://github.com/BCD1210/soju
- Free of charge
- One-line installer and a Homebrew tap