### PR TITLE
Add SessionWatcher to Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@
 - [Rockxy](https://rockxy.io/) - A native HTTP debugging proxy to capture, inspect, and modify HTTP/HTTPS, WebSocket, and GraphQL traffic. [![Open-Source Software][OSS Icon]](https://github.com/RockxyApp/Rockxy)
 - [Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace) - A MySQL & MariaDB database manager. [![Open-Source Software][OSS Icon]](https://github.com/Sequel-Ace/Sequel-Ace) ![Freeware][Freeware Icon]
 - [Sequel Pro](http://www.sequelpro.com/) - A MySQL database manager. [![Open-Source Software][OSS Icon]](https://github.com/sequelpro/sequelpro) ![Freeware][Freeware Icon]
+- [SessionWatcher](https://sessionwatcher.com) - Track usage limits, quotas and spend for AI coding tools including Claude Code, Codex and Cursor, from the menu bar.
 - [SnippetsLab](https://www.renfei.org/snippets-lab/) - Manage and organise snippets of code.
 - [SourceTree](https://www.sourcetreeapp.com/) - A free Git & Mercurial client. ![Freeware][Freeware Icon]
 - [SSH Keys Manager](https://github.com/Stmol/ssh-keys-manager-macos-app) - Native macOS app for managing SSH keys and SSH config entries. [![Open-Source Software][OSS Icon]](https://github.com/Stmol/ssh-keys-manager-macos-app) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://sessionwatcher.com
3. [x] Why should this project be added:

I want to be upfront about rule 1, because this app sits near that line and you
should be the judge of it.

SessionWatcher is a usage meter, not an interface to a generative tool. It does
not send prompts, does not wrap a chatbot, does not generate anything, and never
reads your code or your conversations. It reads quota and spend figures and
draws them in the menu bar, in the same way iStat Menus draws CPU and memory.
The thing being measured happens to be an AI subscription. If you read the rule
as covering anything that touches an LLM API at all, then this does not qualify
and I would rather you close it than have it sit in the queue.

Disclosure: I am the developer.

It is a native Swift app, macOS 14 or later, Apple Silicon and Intel, no
Electron and no web views. It covers 15 providers and shows session windows,
weekly caps, spend and reset times.

4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (between Sequel Pro and SnippetsLab)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

No icon applies. It is paid and closed source, so it carries neither the OSS nor
the Freeware badge, matching entries like Base 2 and SnippetsLab in the same
section.

On the commercial trial requirement: there is a 7 day trial covering Claude,
Codex and Cursor with no credit card, so you can validate it before merging.
