### PR TITLE
Add StandLock to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@
 - [ScreenTranslate](https://screentranslate.filient.ai/) - Capture any area or select text to translate instantly, fully on-device. [![Open-Source Software][OSS Icon]](https://github.com/hcmhcs/screenTranslate) ![Freeware][Freeware Icon]
 - [SelfControl](https://selfcontrolapp.com/) - Block access to distracting websites. [![Open-Source Software][OSS Icon]](https://github.com/SelfControlApp/selfcontrol/) ![Freeware][Freeware Icon]
 - [Simplenote](https://simplenote.com/) - Simple cross-platform note taking app with cloud-based syncing. ![Freeware][Freeware Icon]
+- [StandLock](https://standlock.app) - Menu bar break timer that locks the screen until you stand up, skipping breaks during meetings and calls. [![Open-Source Software][OSS Icon]](https://github.com/yagizdo/standlock) ![Freeware][Freeware Icon]
 - [Taskade](https://apps.apple.com/us/app/taskade-manage-anything/id1490048917/) - Real-time organization and task management tool.
 - [TaskPaper](https://www.taskpaper.com/) - Plain text to-do lists.
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://standlock.app (source: https://github.com/yagizdo/standlock)
3. [x] Why should this project be added:

   StandLock is a break reminder for people who dismiss break reminders. Where the timers already on the list stop at a notification, StandLock can lock the screen for the length of the break, at three levels you pick per schedule: a dismissible notification, a dimmed screen with a countdown, or a full input lock. An emergency key combo is always available.

   It reads the calendar and checks for active camera or microphone use, so it stays quiet during meetings and calls. Nothing leaves the machine and there is no account.

   Native Swift, no Electron. MIT licensed, free, no paid tier. Productivity has no break or posture reminder yet; the nearest entries are f.lux and HazeOver, which change how the screen looks rather than interrupting the session.

   Disclosure: I am the author.

4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (Simplenote → StandLock → Taskade)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)