### PR TITLE
Add WinKeys to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
+- [WinKeys](https://github.com/neural-beat/winkeys) - Windows keyboard shortcuts that work on macOS, for people who just switched. [![Open-Source Software][OSS Icon]](https://github.com/neural-beat/winkeys) ![Freeware][Freeware Icon]
 
 
 ### Sharing Files


### PR DESCRIPTION
Adds [WinKeys](https://github.com/neural-beat/winkeys) to **Productivity**, in
alphabetical position after Timing.

A menu bar app that makes Windows keyboard habits work on macOS: `Ctrl+C`,
`Ctrl+V`, `Ctrl+Z` and the rest, with `Home`/`End` going to the start and end of
the line rather than the document. It shows the Mac equivalent each time it
translates one, so the user eventually stops needing it.

Karabiner is already listed and remains the right tool for general keyboard
customisation. WinKeys is narrower on purpose: it is aimed at people who just
moved from Windows, works with one switch and no configuration, and stays out of
terminals, editors with an embedded terminal, virtual machines and remote
sessions, where `Ctrl` already means something else.

Open source (GPL-3.0), free, Swift, universal binary for Intel and Apple Silicon,
macOS 10.13 or later. Single line added, existing icon format, no other changes.

Disclosure: this contribution was prepared with AI assistance, and checked
against the list's format and ordering before opening.