### PR TITLE
Add UpSit to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@
 - [Telephone](http://www.64characters.com/telephone/) - A SIP softphone. Make phone calls over the Internet or your company’s network. [![Open-Source Software][OSS Icon]](https://github.com/eofster/Telephone) ![Freeware][Freeware Icon]
 - [TextExpander](https://smilesoftware.com/textexpander) - Create custom keyboard shortcuts for frequently-used text and pictures.
 - [Timing](https://timingapp.com/) - Automatic time and productivity tracking for Mac. Helps you stay on track with your work and ensures no billable hours get lost if you are billing hourly.
+- [UpSit](https://www.upsit.online) - Tracks posture via webcam and nudges you when you slouch, entirely on-device using a local ML model — nothing is ever uploaded. [![Open-Source Software][OSS Icon]](https://github.com/aykhanstoic/superposture)
 
 
 ### Sharing Files


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://www.upsit.online (source: https://github.com/aykhanstoic/superposture)
3. [x] Why should this project be added: UpSit is a native macOS/Windows/Linux app (Tauri, not Electron) that tracks sitting posture via the webcam using an on-device MediaPipe pose-detection model, then nudges you when you slouch. The model is used as one step in a larger local scoring pipeline, not a generative/LLM wrapper — no frame or landmark ever leaves the device, and the app has no cloud backend for its core function. It's open source (MIT). It's a paid app ($4.99 one-time) but offers a 3-day free trial, satisfying the commercial-app guideline.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) — OSS icon added (linking to source); no Freeware icon since it's a paid app, not free.