### PR TITLE
Add Recurred

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
     - [E-Book Utilities](#e-book-utilities)
     - [Editors](#editors)
     - [Email Utilities](#email-utilities)
+    - [Finance](#finance)
     - [Finder](#finder)
     - [Games](#games)
     - [Graphics](#graphics)
@@ -158,6 +159,11 @@
 - [Airmail](http://airmailapp.com/) - Lightning fast email client designed for El Capitan.
 - [MailMate](https://freron.com/) - Advanced IMAP email client, featuring extensive keyboard control and Markdown support.
 - [Mailplane](https://mailplaneapp.com/) - A tightly integreted client for Google Mail, Inbox, Calender, and Contacts.
+
+
+### Finance
+
+- [Recurred](https://gozman.space/apps/recurred) - Track subscriptions and recurring bills with renewal reminders, yearly cost breakdowns, and a cancel-suggesting Optimizer, synced privately through iCloud. ![Freeware][Freeware Icon]
 
 
 ### Finder


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://gozman.space/apps/recurred
3. [x] Why should this project be added: Recurred is a fully native macOS/iPadOS/iOS app for tracking subscriptions and recurring bills — renewal reminders, per-year cost breakdowns, multi-currency totals, and an Optimizer that flags services you rarely use and could cancel. It's free with every feature unlocked, no account, no ads, and no tracking; data stays on device and syncs only through the user's own iCloud. It fills a gap in the list, which currently has no personal-finance or subscription-management app, so I added a new **Finance** category for it. It is not an "AI wrapper" — it's a manual finance tracker whose only optional AI touch is on-device natural-language entry parsing; that is an incidental convenience, not its main purpose.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware): Freeware icon added (free, closed-source).