### PR TITLE
Add Codex Account Switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 - [Anvil](http://anvilformac.com/) - Serve up static sites and Rack apps with simple URLs and zero configuration. ![Freeware][Freeware Icon]
 - [Base 2](http://menial.co.uk/base/) - A GUI for managing SQLite databases.
 - [CocoaRestClient](https://mmattozzi.github.io/cocoa-rest-client) - An app for testing REST endpoints. [![Open-Source Software][OSS Icon]](https://github.com/mmattozzi/cocoa-rest-client) ![Freeware][Freeware Icon]
+- [Codex Account Switcher](https://liuzhao1225.github.io/codex-account-switcher/) - Native menu bar utility for switching multiple Codex accounts locally without Terminal commands or config-file editing. [![Open-Source Software][OSS Icon]](https://github.com/liuzhao1225/codex-account-switcher) ![Freeware][Freeware Icon]
 - [Cork](https://corkmac.app) - A fast, intuitive Homebrew GUI [![Open-Source Software][OSS Icon]](https://github.com/buresdv/Cork)
 - [Dash](https://kapeli.com/dash) - An API Documentation Browser and Code Snippet Manager.
 - [Decode](https://microcodingapps.com/products/decode.html) - Converts Xcode Interface Builder files (Xib and Storyboard files) to Swift source code.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://liuzhao1225.github.io/codex-account-switcher/
3. [x] Why should this project be added: Codex Account Switcher is a native SwiftUI menu bar utility that lets people switch locally stored Codex accounts without Terminal commands or config-file editing. It does not provide prompts, chat, agents, code generation, or model API access; its scope is local account selection for the Codex Desktop app and newly started Codex CLI sessions. The app is open source under MIT and provides a signed and notarized free download.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

Disclosure: I am the author of Codex Account Switcher.
