### PR TITLE
Add Better Resource Monitor to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@
 - [Bartender](https://www.macbartender.com/) - Organize your menu bar apps.
 - [Batch Image Resizer](http://www.ironstarmedia.co.uk/resources/osx-image-resizer/) - Resize a large number of images quickly on your computer. ![Freeware][Freeware Icon]
 - [BeardedSpice](https://github.com/beardedspice/beardedspice) - Control web based media players with the media keys found on Mac keyboards. [![Open-Source Software][OSS Icon]](https://github.com/beardedspice/beardedspice) ![Freeware][Freeware Icon]
+- [Better Resource Monitor](https://better-resource-monitor.alexpedersen.dev/) - Lightweight macOS menu bar monitor for CPU, memory, storage, GPU, and network usage. [![Open-Source Software][OSS Icon]](https://github.com/alexx855/better-resource-monitor) ![Freeware][Freeware Icon]
 - [BetterZip](https://macitbetter.com/) - A very capable and full-featured archive manager.
 - [BitBar](https://github.com/matryer/bitbar) - Display output of any script to the menu bar. [![Open-Source Software][OSS Icon]](https://github.com/matryer/bitbar) ![Freeware][Freeware Icon]
 - [Boring Notch](https://github.com/TheBoredTeam/boring.notch) - Turns your MacBook notch into a dynamic hub with media controls, calendar integration, and more. [![Open-Source Software][OSS Icon]](https://github.com/TheBoredTeam/boring.notch) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://better-resource-monitor.alexpedersen.dev/
3. [x] Why should this project be added: Better Resource Monitor is a lightweight, open-source macOS menu bar monitor for CPU, memory, storage, GPU, and network usage. It is MIT-licensed, free, sandboxed, and has no telemetry.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

Disclosure: I maintain Better Resource Monitor. It is not AI-adjacent and does not use Electron.