### PR TITLE
Add Whisk (Productivity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@
 - [CloudApp](https://www.getcloudapp.com/) - Capture and share files and screenshots instantly.
 - [Jumpshare](https://itunes.apple.com/us/app/jumpshare/id889922906) - Real-time file sharing app with support for instantly sharing code / Markdown, annotating screenshots, screen recording, and voice recording. ![Freeware][Freeware Icon]
 - [mac2imgur](https://github.com/mileswd/mac2imgur) - Upload images and screenshots to Imgur. [![Open-Source Software][OSS Icon]](https://github.com/mileswd/mac2imgur) ![Freeware][Freeware Icon]
+- [Whisk](https://github.com/nathan-poncet/whisk) - Keyboard-first clipboard manager with a Liquid Glass panel, filters by app and content type, and rich previews. [![Open-Source Software][OSS Icon]](https://github.com/nathan-poncet/whisk) ![Freeware][Freeware Icon]
 - [Monosnap](https://monosnap.com) - Annotate and upload images and screenshots, supports many backends like S3, SFTP, WebDAV, Dropbox, etc. ![Freeware][Freeware Icon]
 - [Transmission](https://www.transmissionbt.com/) - Simple, lightweight, multi-platform torrent client. [![Open-Source Software][OSS Icon]](https://github.com/transmission/transmission) ![Freeware][Freeware Icon]
 


### PR DESCRIPTION
Adds **[Whisk](https://github.com/nathan-poncet/whisk)** — an open-source (GPL-3.0) clipboard manager for macOS, written in pure Swift/SwiftUI with zero third-party dependencies.

Highlights:
- Liquid Glass bottom panel (macOS 26 look, translucent-material fallback down to macOS 14)
- Keyboard-first: arrows navigate cards and filter chips, Return pastes into the previously focused field
- Filters by source application (with app icons) and content category (text, code, color, link, image, files)
- Rich previews: link metadata, QuickLook file thumbnails, syntax-highlighted code, color swatches
- Installable via Homebrew: `brew install nathan-poncet/tap/whisk`

Demo video and screenshots in the README.
