### PR TITLE
Add Tr4wl to Finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@
 - [Pathly](https://pathly.sophinauta.com/) - Copy any file or folder path from Finder: full, directory, URL, or Git-relative.
 - [Quicklook-Plugins](https://github.com/sindresorhus/quick-look-plugins) - List of extra quicklook plugins to enable previewing more filetypes in the Finder.
 - [TotalFinder](http://totalfinder.binaryage.com/) - A powerful alternative to Finder.
+- [Tr4wl](https://tr4wl.com/) - Filename search for the files Spotlight does not index, including dotfiles, caches, and the contents of app bundles.
 - [XtraFinder](https://www.trankynam.com/xtrafinder/) - Adds useful features to Finder. ![Freeware][Freeware Icon]
 
 


### PR DESCRIPTION
Tr4wl is a native macOS app that searches by filename in the places Spotlight leaves out: dotfiles, caches, build output, gaps in `~/Library` and app containers, and inside `.app` bundles. It builds its own in-memory index by walking the filesystem directly and keeps it current with FSEvents.

- Website: https://tr4wl.com/
- macOS 14 (Sonoma) or later, Apple silicon
- Signed and notarized with a Developer ID, distributed outside the App Store
- Paid (one-time purchase, 14-day trial), so no Freeware or Open Source badge

Placed in `Finder` alphabetically, between TotalFinder and XtraFinder.