### PR TITLE
Add NoMicSwitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 - [Fader](https://fader.pantafive.dev) - Menu bar volume mixer with per-app volume, one-click audio output switching, and Bluetooth headphone control. [![Open-Source Software][OSS Icon]](https://github.com/pantafive/fader) ![Freeware][Freeware Icon]
 - [krisp](https://krisp.ai/) - AI-powered app that removes background noise and echo from meetings leaving only human voice.
 - [Murmur](https://murmurtts.com/) - On-device text-to-speech studio with 860+ voices, voice cloning, and four AI models running entirely on Apple Silicon via MLX.
+- [NoMicSwitch](https://github.com/marks-zyz/NoMicSwitch) - Pins the default audio input to the built-in mic and locks the input volume, so AirPods never take the microphone over. [![Open-Source Software][OSS Icon]](https://github.com/marks-zyz/NoMicSwitch) ![Freeware][Freeware Icon]
 - [Plug](https://plugformac.com) - Discover and listen to music from Hype Machine. [![Open-Source Software][OSS Icon]](https://github.com/wulkano/Plug) ![Freeware][Freeware Icon]
 - [Recordia](https://sindresorhus.com/recordia) - Record audio directly from the menu bar or with a global keyboard shortcut.
 - [VOX Player](https://coppertino.com/vox/mac) - Play numerous lossy and lossless audio formats.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software. NoMicSwitch contains no AI or LLM functionality of any kind; it is a CoreAudio daemon.
2. [x] Project URL: https://github.com/marks-zyz/NoMicSwitch
3. [x] Why should this project be added: macOS switches the default audio input to the AirPods microphone whenever they connect, which both degrades your recorded audio and, because the Bluetooth link falls back to the hands free profile, degrades playback at the same time. The Audio section already lists Audio Profile Manager for pinning devices, but nothing headless, and nothing that also restores the input volume when a conferencing app lowers it. NoMicSwitch does both in a single event driven process (no polling, no CPU while idle), pins any device by its CoreAudio UID rather than its localized name, and installs through Homebrew as a managed service.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (between Murmur and Plug in the Audio section)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware). Both, since it is public domain (Unlicense).
