### PR TITLE
Add TendKit to Command Line Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@
 - [Mocker](https://github.com/us/mocker) - Docker-compatible container CLI for macOS, built on Apple's Containerization framework. [![Open-Source Software][OSS Icon]](https://github.com/us/mocker) ![Freeware][Freeware Icon]
 - [mas](https://github.com/mas-cli/mas) - A CLI for the Mac App Store. [![Open-Source Software][OSS Icon]](https://github.com/mas-cli/mas) ![Freeware][Freeware Icon]
 - [quokka](https://github.com/dutradotdev/quokka) - Inspect and clean a USB-connected iPhone from the terminal. No jailbreak required. [![Open-Source Software][OSS Icon]](https://github.com/dutradotdev/quokka) ![Freeware][Freeware Icon]
+- [TendKit](https://github.com/eoctet/tendkit) - Discover, track, and safely update developer tools across macOS and Linux workstations. [![Open-Source Software][OSS Icon]](https://github.com/eoctet/tendkit) ![Freeware][Freeware Icon]
 
 ## macOS Utilities
 


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://github.com/eoctet/tendkit
3. [x] Why should this project be added: TendKit provides an interactive terminal interface for discovering, tracking, and safely updating developer tools across macOS and Linux workstations. It is free, open source, and does not use Electron or AI.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)
