### PR TITLE
Add WhereAmIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@
 - [Ukelele](http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=ukelele) - Unicode Keyboard Layout Editor. ![Freeware][Freeware Icon]
 - [Übersicht](http://tracesof.net/uebersicht/) - Run system commands and display their output on your desktop as widgets. [![Open-Source Software][OSS Icon]](https://github.com/felixhageloh/uebersicht) ![Freeware][Freeware Icon]
 - [The Unarchiver](https://theunarchiver.com/) - Unarchive many different kinds of archive files. ![Freeware][Freeware Icon]
+- [WhereAmIP](https://frinsen.github.io/whereamip/) - Shows the country flag of your real exit IP in the menu bar and warns about VPN, IPv6 and DNS leaks. [![Open-Source Software][OSS Icon]](https://github.com/frinsen/whereamip) ![Freeware][Freeware Icon]
 - [Wineskin](https://github.com/Gcenx/WineskinServer) - Run Windows applications and games on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Gcenx/WineskinServer) ![Freeware][Freeware Icon]
 
 ### Video


### PR DESCRIPTION
<!-- Thanks for contributing to awesome-macOS  -->

0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software — WhereAmIP contains no generative-AI or LLM functionality of any kind; it is a native network utility.
2. [x] Project URL: https://frinsen.github.io/whereamip/ (source: https://github.com/frinsen/whereamip, MIT)
3. [x] Why should this project be added: It shows the country flag of the IP your traffic *really* exits from in the menu bar and flips it the moment a VPN takes or loses the default route. It names the VPN that owns the route from the routing table, and warns about IPv6 leaks and DNS leaks past the tunnel and about iCloud Private Relay splitting Safari from the rest. No existing entry in Utilities covers exit-country or VPN-leak visibility. Native AppKit/Swift, no Electron, free, no accounts, no tracking. Installs via Homebrew tap or the MacPorts tree; screenshot in the README.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (Utilities, between The Unarchiver and Wineskin)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) — OSS icon links to the source, primary link to the website, Freeware icon added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUWVucaKwAEi4xPzrTuJvY