### PR TITLE
Add Focuh to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@
 - [Dropzone](https://aptonic.com/) - Create a popup grid of customizable actions that enhance productivity on your Mac.
 - [f.lux](https://justgetflux.com/) - Automatically adjust your computer screen to match lighting. ![Freeware][Freeware Icon]
 - [Fantastical](https://flexibits.com/fantastical) - Complete Calendar app replacement which uses natural language for creating events.
+- [Focuh](https://www.focuh.com) - ADHD-friendly to-do list and week planner with a focus timer and system-wide website and app blocking. ![Freeware][Freeware Icon]
 - [Hazel](https://www.noodlesoft.com/hazel.php) - Create rules to automatically keep your files organized.
 - [HazeOver](https://hazeover.com/) - Turn distractions down and focus on your current task.
 - [HyperDock](https://bahoom.com/hyperdock/) - Select individual application window.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://www.focuh.com (download: https://www.focuh.com/download)
3. [x] Why should this project be added: Focuh is a native macOS app (Tauri, not Electron) that combines a to-do list and week planner with a focus timer and system-wide website/app blocking, so distraction blocking and planning live in one app instead of two. It is aimed at people with ADHD and is completely free with no paid tier or subscription. It is not an AI wrapper: it is a task manager, and its core features work without any generative model.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) — Freeware icon added; the app is closed source, so no OSS icon.

Added one line to Productivity:

`- [Focuh](https://www.focuh.com) - ADHD-friendly to-do list and week planner with a focus timer and system-wide website and app blocking. ![Freeware][Freeware Icon]`

Disclosure: I am the developer of Focuh.