### PR TITLE
Add DevPeek to Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
 - [Cork](https://corkmac.app) - A fast, intuitive Homebrew GUI [![Open-Source Software][OSS Icon]](https://github.com/buresdv/Cork)
 - [Dash](https://kapeli.com/dash) - An API Documentation Browser and Code Snippet Manager.
 - [Decode](https://microcodingapps.com/products/decode.html) - Converts Xcode Interface Builder files (Xib and Storyboard files) to Swift source code.
+- [DevPeek](https://devpeek.ypgao.com/) - A free HTTP(S) debugging proxy with request mock, automatic parameter decryption, and WebSocket inspection. ![Freeware][Freeware Icon]
 - [Fork](https://git-fork.com/) - a fast and friendly git client for Mac.
 - [DevUtils](https://devutils.com) - All-in-one toolbox for developers. 42+ beautifully crafted useful developer tools, native macOS app, work offline.
 - [Gas Mask](https://github.com/2ndalpha/gasmask) - A simple hosts file manager which allows editing of host files and switching between them. [![Open-Source Software][OSS Icon]](https://github.com/2ndalpha/gasmask) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://devpeek.ypgao.com/
3. [x] Why should this project be added: DevPeek is a free Tauri-based HTTP(S) debugging proxy for macOS (Apple Silicon) and Windows. It captures traffic, mocks requests/responses, automatically decrypts parameters, inspects WebSockets, and replays requests. It is a lightweight alternative to Charles / Fiddler / Proxyman, already listed in this Developers section. Related issue: https://github.com/iCHAIT/awesome-macOS/issues/1066
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)

Notes:
- Primary link is the official website, as required.
- Closed-source and free for local features, so Freeware icon only (no OSS icon).
- Desktop shell is Tauri, not Electron.


Made with [Cursor](https://cursor.com)