### PR TITLE
Add MacPilot to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@
 - [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html) - Protect your privacy.
 - [MacDown](http://macdown.uranusjr.com/) - Markdown editor. [![Open-Source Software][OSS Icon]](https://github.com/MacDownApp/macdown) ![Freeware][Freeware Icon]
 - [Mackup](https://github.com/lra/mackup) - Keep your application settings in sync. [![Open-Source Software][OSS Icon]](https://github.com/lra/mackup) ![Freeware][Freeware Icon]
+- [MacPilot](https://github.com/misswell/MacPilot) - An open-source menu bar toolbox: per-app quit rules, BLE proximity unlock, window switching, clipboard history, smooth scrolling, PiP, screen capture, and screen recording. [![Open-Source Software][OSS Icon]](https://github.com/misswell/MacPilot) ![Freeware][Freeware Icon]
 - [MacPacker](https://macpacker.app) - Preview and extract archives. Native 7-Zip alternative. [![Open-Source Software][OSS Icon]](https://github.com/sarensw/MacPacker) ![Freeware][Freeware Icon]
 - [MacPass](https://macpass.github.io/) - Password Manager. [![Open-Source Software][OSS Icon]](https://github.com/MacPass/MacPass) ![Freeware][Freeware Icon]
 - [Media Converter](http://media-converter.sourceforge.net/) - Simple (drag and drop) but advanced media conversion. [![Open-Source Software][OSS Icon]](https://sourceforge.net/p/media-converter/code/ci/master/tree/) ![Freeware][Freeware Icon]


### PR DESCRIPTION
Adds [MacPilot](https://github.com/misswell/MacPilot) to the Utilities section (alphabetical order, between Mackup and MacPacker).

MacPilot is an open-source, notarized macOS menu bar toolbox written in Swift 6 / SwiftUI with zero third-party dependencies. It combines per-app quit rules, BLE proximity lock/unlock (iPhone / Apple Watch), a window switcher, clipboard history, smooth scrolling, Picture-in-Picture, screen capture with OCR, and an HDR screen recording engine.

- Repo: https://github.com/misswell/MacPilot
- Releases (Developer ID signed, notarized): https://github.com/misswell/MacPilot/releases/latest