### PR TITLE
Add Sankore app to productivity tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@
 - [Qbserve](https://qotoqot.com/qbserve/) - Automatic time and project tracking, timesheets, invoicing, and real-time productivity feedback.
 - [Quicksilver](https://qsapp.com/) - Control your Mac quickly and elegantly. [![Open-Source Software][OSS Icon]](https://github.com/quicksilver/Quicksilver) ![Freeware][Freeware Icon]
 - [Rocket](http://matthewpalmer.net/rocket/) - Makes typing emoji faster and easier using Slack-style shortcuts. ![Freeware][Freeware Icon]
+- [Sankore](https://sankoreapp.com) - Convert documents (PDF, DOCX, XLSX, PPTX) to clean Markdown, entirely on-device, for feeding into Claude, ChatGPT, and similar tools.
 - [ScreenTranslate](https://screentranslate.filient.ai/) - Capture any area or select text to translate instantly, fully on-device. [![Open-Source Software][OSS Icon]](https://github.com/hcmhcs/screenTranslate) ![Freeware][Freeware Icon]
 - [SelfControl](https://selfcontrolapp.com/) - Block access to distracting websites. [![Open-Source Software][OSS Icon]](https://github.com/SelfControlApp/selfcontrol/) ![Freeware][Freeware Icon]
 - [Simplenote](https://simplenote.com/) - Simple cross-platform note taking app with cloud-based syncing. ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software - Sankore's conversion pipeline uses local, specialized ML models (OCR/layout detection) to convert documents to Markdown. It does not interface with any generative AI/LLM API - it doesn't wrap or call Claude/ChatGPT. The "feeding into Claude/ChatGPT" framing describes what a user does with the output afterward, not anything Sankore itself does internally.
2. [x] Project URL: https://sankoreapp.com
3. [x] Why should this project be added: A native (non-Electron) macOS document-to-Markdown converter using local ML for OCR/layout detection - no data ever leaves the device. Free tier is a genuine, permanent free tier (not a time-limited trial), letting maintainers fully validate core functionality before deciding on inclusion.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) - N/A, Sankore is neither open-source nor pure freeware (freemium, one-time paid unlock), so no OSS/Freeware icon applies.