### PR TITLE
Add Dynamic Menu Bar to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@
 - [Deliveries](http://junecloud.com/software/mac/deliveries.html) - Beautiful and simple package tracking.
 - [DisableMonitor](https://github.com/Eun/DisableMonitor) - Easily disable or enable a monitor on your Mac. [![Open-Source Software][OSS Icon]](https://github.com/Eun/DisableMonitor) ![Freeware][Freeware Icon]
 - [Dozer](https://github.com/Mortennn/Dozer) - Hide MacOS menubar items. [![Open-Source Software][OSS Icon]](https://github.com/Mortennn/Dozer) ![Freeware][Freeware Icon]
+- [Dynamic Menu Bar](https://dynamicmenubar.com) - Change the color and shape of the macOS menu bar with live screen-matched colors, gradients, a music visualizer and per-app profiles.
 - [EtreCheck](http://etrecheck.com) - Output system information and configuration to get more informed help from Apple support professionals. ![Freeware][Freeware Icon]
 - [Equinox](https://equinoxmac.com) - Create macOS dynamic wallpapers. [![Open-Source Software][OSS Icon]](https://github.com/rlxone/Equinox) ![Freeware][Freeware Icon]
 - [Fanny](http://fannywidget.com/) - Notification Center widget and menu bar application to monitor your Mac's fans and CPU temperature. [![Open-Source Software][OSS Icon]](https://github.com/DanielStormApps/Fanny) ![Freeware][Freeware Icon]


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://dynamicmenubar.com
3. [x] Why should this project be added: Dynamic Menu Bar is a native Swift/SwiftUI macOS app (not Electron) for macOS 26 Tahoe that changes the color and shape of the menu bar — live screen-matched colors, gradients, blur, a pill shape, rounded corners, a music visualizer and per-app profiles. The list has icon organizers (Bartender, Dozer) but nothing for the bar's own appearance. Commercial, with a free 7-day trial of every feature for maintainers to validate. Not AI software. Disclosure: I am the developer.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (Utilities: after Dozer, before EtreCheck)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware) — none apply, the app is commercial and closed source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
