### PR TITLE
Add Pelmet to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@
 - [OnyX](http://www.titanium.free.fr/) -  Multifunction utility to verify disks and files, run cleaning and system maintenance tasks, configure hidden options and more. ![Freeware][Freeware Icon]
 - [Paparazzi](http://derailer.org/paparazzi/) - A small utility that makes screenshots of webpages. ![Freeware][Freeware Icon]
 - [Paragon NTFS](http://www.paragon-drivers.com/ntfs-mac/) - World fastest NTFS driver.
+- [Pelmet](https://pelmet.fif7y.com) - Menu bar manager built for macOS 27's rebuilt menu bar. Hides the icons you don't need until you do. [![Open-Source Software][OSS Icon]](https://github.com/fif7y/pelmet) ![Freeware][Freeware Icon]
 - [Pulse](https://www.pulseticker.app/) - Native menu bar market tracker for stocks, cryptocurrencies, indices, ETFs, and portfolio P&L. [![Open-Source Software][OSS Icon]](https://github.com/fatwang2/Pulse) ![Freeware][Freeware Icon]
 - [PureMac](https://github.com/momenbasel/PureMac) - Free and open-source macOS cleaner that removes system caches, Xcode junk, Homebrew cache, and more with no telemetry or network calls. [![Open-Source Software][OSS Icon]](https://github.com/momenbasel/PureMac) ![Freeware][Freeware Icon]
 - [Radio Silence](https://radiosilenceapp.com) - Simple to use firewall and network monitor.


### PR DESCRIPTION
0. [x] I have read the [Contribution Guidelines](https://github.com/iCHAIT/awesome-macOS/blob/master/.github/contributing.md)
1. [x] I confirm that I have read and understood the sections about "AI"-adjacent software
2. [x] Project URL: https://pelmet.fif7y.com (source: https://github.com/fif7y/pelmet)
3. [x] Why should this project be added: Pelmet is a free, open source (GPLv3) menu bar manager built for the menu bar Apple rebuilt in macOS 27. It hides the icons you don't need until you hover, click, or press a shortcut, with three sections, a layout editor, ⌘-drag in the bar and per-display rules. Native Swift, no Electron, no account, no analytics. The existing entries in this space (Bartender, Hidden Bar, Ice) predate the macOS 27 menu bar.
4. [x] End all descriptions with a full stop/period
5. [x] Entry is ordered alphabetically (Utilities, between Paragon NTFS and Pulse)
6. [x] Appropriate icon(s) added if applicable (OSS, freeware)